### PR TITLE
Export envvar to let debconf know that we are in non-interactive shell.

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER Alber Sanchez
 
 
 # install
-RUN apt-get -qq update && apt-get install --fix-missing -y --force-yes \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get -qq update && apt-get install --fix-missing -y --force-yes \
 	openssh-server \
 	openssh-client \
 	sudo \


### PR DESCRIPTION
Source: http://stackoverflow.com/questions/22466255/is-it-possibe-to-answer-dialog-questions-when-installing-under-docker
